### PR TITLE
add Widget setDrawHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ func main() {
 	btn.SetColor(BLUE)
 	btn.SetSelectionColor(SEL_BLUE)
 	btn.SetLabelColor(255)
-	btn.SetBox(fltk.OFLAT_BOX)
+	btn.SetBox(fltk.OFLAT_FRAME)
 	btn.ClearVisibleFocus()
 	btn.SetCallback(func() {
 		curr += 1

--- a/event_handler.h
+++ b/event_handler.h
@@ -13,13 +13,17 @@ class WidgetWithResizeHandler {
 public:
   virtual void set_resize_handler(uintptr_t handlerId) = 0;
 };
+class WidgetWithDrawHandler {
+public:
+  virtual void set_draw_handler(uintptr_t handlerId) = 0;
+};
 class WidgetWithDeletionHandler {
 public:
   virtual void add_deletion_handler(uintptr_t handlerId) = 0;
 };
 
 template<class BaseWidget>
-class EventHandler : public BaseWidget, public WidgetWithEventHandler, public WidgetWithResizeHandler, public WidgetWithDeletionHandler {
+class EventHandler : public BaseWidget, public WidgetWithEventHandler, public WidgetWithDrawHandler, public WidgetWithResizeHandler, public WidgetWithDeletionHandler {
 public:
   template<class... Arg>
   EventHandler(Arg... args)
@@ -41,6 +45,13 @@ public:
     return BaseWidget::handle(event);
   }
 
+  void draw() override {
+    if (m_drawHandlerId != 0) {
+      _go_callbackHandler(m_drawHandlerId);
+    }
+    return BaseWidget::draw();
+  }
+
   void resize(int x, int y, int w, int h) final {
     BaseWidget::resize(x, y, w, h);
     if (m_resizeHandlerId != 0) {
@@ -53,6 +64,10 @@ public:
     m_eventHandlerId = handlerId;
   }
 
+  void set_draw_handler(uintptr_t handlerId) final {
+    m_drawHandlerId = handlerId;
+  }
+
   void set_resize_handler(uintptr_t handlerId) final {
     m_resizeHandlerId = handlerId;
   }
@@ -63,6 +78,7 @@ public:
 
 protected:
   int m_eventHandlerId = -1;
+  uintptr_t m_drawHandlerId = 0;
   uintptr_t m_resizeHandlerId = 0;
   std::vector<uintptr_t> m_deletionHandlerIds;
 };

--- a/examples/flutter-like/main.go
+++ b/examples/flutter-like/main.go
@@ -9,6 +9,7 @@ import (
 // FLTK uses an RGBI color representation, the I is an index into FLTK's color map
 // Passing 00 as I will use the RGB part of the value
 const GRAY = 0x75757500
+const LIGHT_GRAY = 0xeeeeee00
 const BLUE = 0x42A5F500
 const SEL_BLUE = 0x2196F300
 const WIDTH = 600
@@ -21,6 +22,9 @@ func main() {
 	win.SetLabel("Flutter-like")
 	win.SetColor(fltk.WHITE)
 	bar := fltk.NewBox(fltk.FLAT_BOX, 0, 0, WIDTH, 60, "    FLTK App!")
+	bar.SetDrawHandler(func() { // Shadow under the bar
+		fltk.DrawBox(fltk.FLAT_BOX, 0, 0, WIDTH, 63, LIGHT_GRAY)
+	})
 	bar.SetAlign(fltk.ALIGN_INSIDE | fltk.ALIGN_LEFT)
 	bar.SetLabelColor(255) // this uses the index into the color map, here it's white
 	bar.SetColor(BLUE)
@@ -35,7 +39,7 @@ func main() {
 	btn.SetColor(BLUE)
 	btn.SetSelectionColor(SEL_BLUE)
 	btn.SetLabelColor(255)
-	btn.SetBox(fltk.OFLAT_BOX)
+	btn.SetBox(fltk.OFLAT_FRAME)
 	btn.ClearVisibleFocus()
 	btn.SetCallback(func() {
 		curr += 1

--- a/widget.cxx
+++ b/widget.cxx
@@ -56,6 +56,14 @@ int go_fltk_Widget_set_resize_handler(Fl_Widget* w, uintptr_t id) {
   wh->set_resize_handler(id);
   return 1;
 }
+int go_fltk_Widget_set_draw_handler(Fl_Widget* w, uintptr_t id) {
+  WidgetWithDrawHandler* wh = dynamic_cast<WidgetWithDrawHandler*>(w);
+  if (wh == nullptr) {
+    return 0;
+  }
+  wh->set_draw_handler(id);
+  return 1;
+}
 void go_fltk_Widget_set_labelfont(Fl_Widget *w, int font) {
   w->labelfont((Fl_Font)font);
 }

--- a/widget.go
+++ b/widget.go
@@ -84,7 +84,7 @@ func (w *widget) SetDrawHandler(handler func()) {
 	}
 	w.drawHandlerId = globalCallbackMap.register(handler)
 	if C.go_fltk_Widget_set_draw_handler(w.ptr(), C.uintptr_t(w.drawHandlerId)) == 0 {
-		panic("this widget does not support resize handling")
+		panic("this widget does not support custom drawing")
 	}
 }
 func (w *widget) getWidget() *widget { return w }

--- a/widget.go
+++ b/widget.go
@@ -15,6 +15,7 @@ type widget struct {
 	callbackId        uintptr
 	deletionHandlerId uintptr
 	resizeHandlerId   uintptr
+	drawHandlerId     uintptr
 	eventHandlerId    int
 }
 
@@ -77,6 +78,15 @@ func (w *widget) SetResizeHandler(handler func()) {
 		panic("this widget does not support resize handling")
 	}
 }
+func (w *widget) SetDrawHandler(handler func()) {
+	if w.drawHandlerId > 0 {
+		globalCallbackMap.unregister(w.drawHandlerId)
+	}
+	w.drawHandlerId = globalCallbackMap.register(handler)
+	if C.go_fltk_Widget_set_draw_handler(w.ptr(), C.uintptr_t(w.drawHandlerId)) == 0 {
+		panic("this widget does not support resize handling")
+	}
+}
 func (w *widget) getWidget() *widget { return w }
 func (w *widget) onDelete() {
 	if w.deletionHandlerId > 0 {
@@ -91,6 +101,10 @@ func (w *widget) onDelete() {
 		globalCallbackMap.unregister(w.resizeHandlerId)
 	}
 	w.resizeHandlerId = 0
+	if w.drawHandlerId > 0 {
+		globalCallbackMap.unregister(w.drawHandlerId)
+	}
+	w.drawHandlerId = 0
 	if w.eventHandlerId > 0 {
 		globalEventHandlerMap.unregister(w.eventHandlerId)
 	}
@@ -107,6 +121,10 @@ func (w *widget) Destroy() {
 		globalCallbackMap.unregister(w.resizeHandlerId)
 	}
 	w.resizeHandlerId = 0
+	if w.drawHandlerId > 0 {
+		globalCallbackMap.unregister(w.drawHandlerId)
+	}
+	w.drawHandlerId = 0
 	if w.eventHandlerId > 0 {
 		globalEventHandlerMap.unregister(w.eventHandlerId)
 	}

--- a/widget.h
+++ b/widget.h
@@ -25,6 +25,7 @@ extern "C" {
   extern void go_fltk_Widget_clear_visible_focus(Fl_Widget *w);
   extern void go_fltk_Widget_set_callback(Fl_Widget *w, uintptr_t id);
   extern int go_fltk_Widget_set_resize_handler(Fl_Widget* w, uintptr_t id);
+  extern int go_fltk_Widget_set_draw_handler(Fl_Widget* w, uintptr_t id);
   extern int go_fltk_Widget_add_deletion_handler(Fl_Widget* w, uintptr_t id);
   extern void go_fltk_Widget_when(Fl_Widget* w, int when);
   extern int go_fltk_Widget_set_event_handler(Fl_Widget* w, int id);


### PR DESCRIPTION
Hello
This PR adds Widget::setDrawHandler, along with an example (add to the flutter-like example) of doing custom drawing for a widget. I plan on porting the drawing functions in fl_draw.H at a later point. It's not marked as final since the Gl window already also implements the draw method.