### PR TITLE
add Widget.TakeFocus and version functions

### DIFF
--- a/fltk.go
+++ b/fltk.go
@@ -568,3 +568,11 @@ func _go_drawBox55(x, y, w, h C.int, c C.uint) {
 func _go_drawBox56(x, y, w, h C.int, c C.uint) {
 	setBoxTypeCb[56](int(x), int(y), int(w), int(h), Color(c))
 }
+
+func Version() string {
+	return "v1.4.0"
+}
+
+func GoVersion() string {
+	return "v0.1.0"
+}

--- a/widget.cxx
+++ b/widget.cxx
@@ -172,3 +172,6 @@ void go_fltk_Widget_set_tooltip(Fl_Widget *w, const char *tooltip) {
 Fl_Group *go_fltk_Widget_parent(Fl_Widget *w) {
     return w->parent();
 }
+int go_fltk_Widget_take_focus(Fl_Widget *w) {
+  return w->take_focus();
+}

--- a/widget.go
+++ b/widget.go
@@ -216,3 +216,6 @@ func (w *widget) Parent() *Group {
 	}
 	return w.parent.getGroup()
 }
+func (w *widget) TakeFocus() int {
+	return int(C.go_fltk_Widget_take_focus(w.ptr()))
+}

--- a/widget.h
+++ b/widget.h
@@ -60,6 +60,7 @@ extern "C" {
   extern int go_fltk_Widget_labeltype(Fl_Widget *w);
   extern void go_fltk_Widget_set_tooltip(Fl_Widget* w, const char* tooltip);
   extern Fl_Group *go_fltk_Widget_parent(Fl_Widget *w);
+  extern int go_fltk_Widget_take_focus(Fl_Widget *w);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi

This PR adds Widget.TakeFocus and fltk.Version and GoVersion.
Addresses:
https://github.com/pwiecz/go-fltk/issues/55
https://github.com/pwiecz/go-fltk/issues/51

P.S. Regarding what should be returned from the GoVersion methods, these currently are fixed, but maybe we should find a way to determine the current version of the go package.