### PR TITLE
Added FL_CLOSE event as CLOSE

### DIFF
--- a/enumerations.cxx
+++ b/enumerations.cxx
@@ -68,6 +68,7 @@ const int go_FL_UNFOCUS = FL_UNFOCUS;
 const int go_FL_KEYBOARD = FL_KEYBOARD;
 const int go_FL_KEYDOWN = FL_KEYDOWN;
 const int go_FL_KEYUP = FL_KEYUP;
+const int go_FL_CLOSE = FL_CLOSE;
 const int go_FL_SHORTCUT = FL_SHORTCUT;
 const int go_FL_DEACTIVATE = FL_DEACTIVATE;
 const int go_FL_ACTIVATE = FL_ACTIVATE;

--- a/enumerations.go
+++ b/enumerations.go
@@ -153,6 +153,7 @@ var (
 	KEY            = Event(C.go_FL_KEYDOWN)
 	KEYDOWN        = Event(C.go_FL_KEYDOWN)
 	KEYUP          = Event(C.go_FL_KEYUP)
+	CLOSE          = Event(C.go_FL_CLOSE)
 	SHORTCUT       = Event(C.go_FL_SHORTCUT)
 	DEACTIVATE     = Event(C.go_FL_DEACTIVATE)
 	ACTIVATE       = Event(C.go_FL_ACTIVATE)

--- a/enumerations.h
+++ b/enumerations.h
@@ -68,6 +68,7 @@ extern "C" {
   extern const int go_FL_KEYBOARD;
   extern const int go_FL_KEYDOWN;
   extern const int go_FL_KEYUP;
+  extern const int go_FL_CLOSE;
   extern const int go_FL_SHORTCUT;
   extern const int go_FL_DEACTIVATE;
   extern const int go_FL_ACTIVATE;


### PR DESCRIPTION
The purpose is to allow the programmer to intercept Escape key presses or click of the main Window's [X] Close box, e.g., to save before quitting. Something like this:
```go
type App struct {
	*fltk.Window
}

func (me *App) onEvent(event fltk.Event) bool {
	if fltk.EventType() == fltk.CLOSE ||
		(fltk.EventType() == fltk.KEY && fltk.EventKey() == fltk.ESCAPE) {
		me.save()
	}
	return false
}

func newApp() *App {
	app := &App{Window: nil}
	app.Window = fltk.NewWindow(config.Width, config.Height)
	app.Window.SetEventHandler(app.onEvent)
	return app
}
```