### PR TITLE
added widget.SetOverrideDrawHandler()

### DIFF
--- a/event_handler.h
+++ b/event_handler.h
@@ -16,6 +16,8 @@ public:
 class WidgetWithDrawHandler {
 public:
   virtual void set_draw_handler(uintptr_t handlerId) = 0;
+  virtual void set_override_draw_handler(uintptr_t handlerId) = 0;
+  virtual void draw_base_widget() = 0;
 };
 class WidgetWithDeletionHandler {
 public:
@@ -46,19 +48,26 @@ public:
   }
 
   void draw() override {
-    if (m_drawHandlerId != 0) {
-      _go_callbackHandler(m_drawHandlerId);
+    if (m_overrideDrawHandlerId != 0) {
+      _go_callbackHandler(m_overrideDrawHandlerId);
+    } else {
+      if (m_drawHandlerId != 0) {
+        _go_callbackHandler(m_drawHandlerId);
+      }
+      BaseWidget::draw();
     }
-    return BaseWidget::draw();
   }
 
+  void draw_base_widget() {
+    BaseWidget::draw();
+  }
+  
   void resize(int x, int y, int w, int h) final {
     BaseWidget::resize(x, y, w, h);
     if (m_resizeHandlerId != 0) {
       _go_callbackHandler(m_resizeHandlerId);
     }
   }
-
 
   void set_event_handler(int handlerId) final {
     m_eventHandlerId = handlerId;
@@ -68,6 +77,10 @@ public:
     m_drawHandlerId = handlerId;
   }
 
+  void set_override_draw_handler(uintptr_t handlerId) final {
+    m_overrideDrawHandlerId = handlerId;
+  }
+  
   void set_resize_handler(uintptr_t handlerId) final {
     m_resizeHandlerId = handlerId;
   }
@@ -79,6 +92,7 @@ public:
 protected:
   int m_eventHandlerId = -1;
   uintptr_t m_drawHandlerId = 0;
+  uintptr_t m_overrideDrawHandlerId = 0;
   uintptr_t m_resizeHandlerId = 0;
   std::vector<uintptr_t> m_deletionHandlerIds;
 };

--- a/widget.cxx
+++ b/widget.cxx
@@ -64,6 +64,22 @@ int go_fltk_Widget_set_draw_handler(Fl_Widget* w, uintptr_t id) {
   wh->set_draw_handler(id);
   return 1;
 }
+int go_fltk_Widget_set_override_draw_handler(Fl_Widget* w, uintptr_t id) {
+  WidgetWithDrawHandler* wh = dynamic_cast<WidgetWithDrawHandler*>(w);
+  if (wh == nullptr) {
+    return 0;
+  }
+  wh->set_override_draw_handler(id);
+  return 1;
+}
+int go_fltk_Widget_draw_base_widget(Fl_Widget* w) {
+  WidgetWithDrawHandler* wh = dynamic_cast<WidgetWithDrawHandler*>(w);
+  if (wh == nullptr) {
+    return 0;
+  }
+  wh->draw_base_widget();
+  return 1;
+}
 void go_fltk_Widget_set_labelfont(Fl_Widget *w, int font) {
   w->labelfont((Fl_Font)font);
 }

--- a/widget.h
+++ b/widget.h
@@ -26,6 +26,8 @@ extern "C" {
   extern void go_fltk_Widget_set_callback(Fl_Widget *w, uintptr_t id);
   extern int go_fltk_Widget_set_resize_handler(Fl_Widget* w, uintptr_t id);
   extern int go_fltk_Widget_set_draw_handler(Fl_Widget* w, uintptr_t id);
+  extern int go_fltk_Widget_set_override_draw_handler(Fl_Widget* w, uintptr_t id);
+  extern int go_fltk_Widget_draw_base_widget(Fl_Widget* w);
   extern int go_fltk_Widget_add_deletion_handler(Fl_Widget* w, uintptr_t id);
   extern void go_fltk_Widget_when(Fl_Widget* w, int when);
   extern int go_fltk_Widget_set_event_handler(Fl_Widget* w, int id);


### PR DESCRIPTION
Hello!

I needed a way to completly override the draw-method of a widget, so that i can draw the hole widget in a custom draw-handler.

When i set a draw-handler with widget.SetDrawHandler(), the draw()-method of the widget (in event_handler.h) calls BaseWidget::draw() AFTER the draw-handler, which draws above of my own drawings.

I added a draw-handler, that doesn't call BaseWidget::draw(). Instead the draw-handler can call widget.DrawBaseWidget() if needed. This should not break existing code.

Do you think it is a good idea to add a "override-draw-handler" or is there a better way to disable the original draw-method?
