### PR TITLE
Added Window.SetXClass().

### DIFF
--- a/window.cxx
+++ b/window.cxx
@@ -38,6 +38,10 @@ int go_fltk_Window_y_root(Fl_Window* w) {
   return w->y_root();
 }
 
+void go_fltk_Window_set_xclass(Fl_Window *w, const char *wmclass) {
+  w->xclass(wmclass);
+}
+
 void go_fltk_Window_set_label(Fl_Window *w, const char *label) {
   w->copy_label(label);
 }

--- a/window.go
+++ b/window.go
@@ -32,6 +32,11 @@ func (w *Window) XRoot() int {
 func (w *Window) YRoot() int {
 	return int(C.go_fltk_Window_y_root((*C.Fl_Window)(w.ptr())))
 }
+func (w *Window) SetXClass(wmclass string) {
+	wmclassStr := C.CString(wmclass)
+	defer C.free(unsafe.Pointer(wmclassStr))
+  C.go_fltk_Window_set_xclass((*C.Fl_Window)(w.ptr()), wmclassStr)
+}
 func (w *Window) SetLabel(label string) {
 	labelStr := C.CString(label)
 	defer C.free(unsafe.Pointer(labelStr))

--- a/window.h
+++ b/window.h
@@ -15,6 +15,7 @@ extern "C" {
   extern void go_fltk_Window_show(Fl_Window *w);
   extern int go_fltk_Window_x_root(Fl_Window* w);
   extern int go_fltk_Window_y_root(Fl_Window* w);
+  extern void go_fltk_Window_set_xclass(Fl_Window* w, const char *wmclass);
   extern void go_fltk_Window_set_label(Fl_Window *w, const char *label);
   extern void go_fltk_Window_set_cursor(Fl_Window *w, int cursor);
   extern void go_fltk_Window_set_fullscreen(Fl_Window *w, int flag);


### PR DESCRIPTION
I needed a way to set the X11 wmclass-window-property,
so i added only the SetXClass() Method for Window.