### PR TITLE
add Border and ClearBorder methods to fltk.Window

### DIFF
--- a/window.cxx
+++ b/window.cxx
@@ -67,6 +67,14 @@ void go_fltk_Window_set_non_modal(Fl_Window* w) {
   w->set_non_modal();
 }
 
+void go_fltk_Window_border(Fl_Window *w, int n) {
+  w->border(n);
+}
+
+void go_fltk_Window_clear_border(Fl_Window *w) {
+  w->clear_border();
+}
+
 void go_fltk_Window_set_icons(Fl_Window* w, const Fl_RGB_Image *images[], int length) {
   w->icons(images, length);
 }

--- a/window.go
+++ b/window.go
@@ -66,6 +66,18 @@ func (w *Window) SetNonModal() {
 	C.go_fltk_Window_set_non_modal((*C.Fl_Window)(w.ptr()))
 }
 
+func (w *Window) Border(flag bool) {
+	e := 0
+	if flag {
+		e = 1
+	}
+	C.go_fltk_Window_border((*C.Fl_Window)(w.ptr()), C.int(e))
+}
+
+func (w *Window) ClearBorder() {
+	C.go_fltk_Window_clear_border((*C.Fl_Window)(w.ptr()))
+}
+
 func (w *Window) SetIcons(icons []*RgbImage) {
 	images := make([]*C.Fl_RGB_Image, 0, len(icons))
 	for _, icon := range icons {

--- a/window.h
+++ b/window.h
@@ -22,6 +22,8 @@ extern "C" {
   extern int go_fltk_Window_fullscreen_active(Fl_Window *w);
   extern void go_fltk_Window_set_modal(Fl_Window *w);
   extern void go_fltk_Window_set_non_modal(Fl_Window *w);
+  extern void go_fltk_Window_border(Fl_Window *w, int n);
+  extern void go_fltk_Window_clear_border(Fl_Window *w);
   extern void go_fltk_Window_set_icons(Fl_Window* w, const Fl_RGB_Image* images[], int length);
   extern void go_fltk_Window_size_range(Fl_Window* w, int minW, int minH, int maxW, int maxH, int deltaX, int deltaY, int aspectRatio);
   extern void* go_fltk_Window_xid(Fl_Window* w);


### PR DESCRIPTION
This ports the `border` and `clearborder` methods from FL_Window to Go. These utilities can be used to disable the window border, so that windows no longer have the bar with the title and close/window buttons.