### PR TITLE
Add to Grid widget the clear layout method

### DIFF
--- a/grid.cxx
+++ b/grid.cxx
@@ -20,6 +20,10 @@ void go_fltk_Grid_set_layout(Fl_Grid* grid, int rows, int columns, int margin,
   grid->layout(rows, columns, margin, gap);
 }
 
+void go_fltk_Grid_clear_layout(Fl_Grid* grid) {
+  grid->clear_layout();
+}
+
 void go_fltk_Grid_set_show_grid(Fl_Grid *grid, int show) {
   grid->show_grid(show);
 }

--- a/grid.go
+++ b/grid.go
@@ -20,6 +20,11 @@ func (g *Grid) SetLayout(rows, columns, margin, gap int) {
 	C.go_fltk_Grid_set_layout((*C.Fl_Grid)(g.ptr()), C.int(rows), C.int(columns), C.int(margin), C.int(gap))
 }
 
+// ClearLayout reset the layout without removing it's children.
+// First removes all rows and columns from the grid setting them to 'zero',
+// then hides all the children on the Grid. 
+// These can be displayed again by defining a new layout, 
+// showing each child and then adding them again
 func (g *Grid) ClearLayout() {
 	C.go_fltk_Grid_clear_layout((*C.Fl_Grid)(g.ptr()))
 }

--- a/grid.go
+++ b/grid.go
@@ -20,6 +20,10 @@ func (g *Grid) SetLayout(rows, columns, margin, gap int) {
 	C.go_fltk_Grid_set_layout((*C.Fl_Grid)(g.ptr()), C.int(rows), C.int(columns), C.int(margin), C.int(gap))
 }
 
+func (g *Grid) ClearLayout() {
+	C.go_fltk_Grid_clear_layout((*C.Fl_Grid)(g.ptr()))
+}
+
 func (g *Grid) SetShowGrid(show bool) {
 	if show {
 		C.go_fltk_Grid_set_show_grid((*C.Fl_Grid)(g.ptr()), 1)

--- a/grid.go
+++ b/grid.go
@@ -22,8 +22,8 @@ func (g *Grid) SetLayout(rows, columns, margin, gap int) {
 
 // ClearLayout reset the layout without removing it's children.
 // First removes all rows and columns from the grid setting them to 'zero',
-// then hides all the children on the Grid. 
-// These can be displayed again by defining a new layout, 
+// then hides all the children on the Grid.
+// These can be displayed again by defining a new layout,
 // showing each child and then adding them again
 func (g *Grid) ClearLayout() {
 	C.go_fltk_Grid_clear_layout((*C.Fl_Grid)(g.ptr()))

--- a/grid.h
+++ b/grid.h
@@ -12,6 +12,7 @@ extern "C" {
 
   extern void go_fltk_Grid_set_layout(Fl_Grid* grid, int rows, int columns, int margin,
                                       int gap);
+  extern void go_fltk_Grid_clear_layout(Fl_Grid* grid);
 
   extern void go_fltk_Grid_set_show_grid(Fl_Grid *grid, int show);
   extern void go_fltk_Grid_set_show_grid_and_color(Fl_Grid *grid, int show,


### PR DESCRIPTION
Add a simple wrapper of the [`clear_layout` method of the FL_Grid Class in FLTK](https://www.fltk.org/doc-1.4/classFl__Grid.html#aa7c37c263f358c17e7d9e7c01880a78e) to the golang fltk wrapper.